### PR TITLE
Remove redundant test case in SemaphoreTests

### DIFF
--- a/src/ConcurrencyToolkit.Tests/Synchronization/SemaphoreTests.cs
+++ b/src/ConcurrencyToolkit.Tests/Synchronization/SemaphoreTests.cs
@@ -493,7 +493,6 @@ public abstract class SemaphoreTestsBase
   [TestCase(1, 4)]
   [TestCase(2, 4)]
   [TestCase(3, 4)]
-  [TestCase(4, 4)]
   [Timeout(TimeoutMs)]
   public void SemaphoreShouldLimitSyncConsumers(int limit, int threads)
   {


### PR DESCRIPTION
Fixes for #7 
The test case [TestCase(4,4)] in the SemaphoreShouldLimitSyncConsumers test was removed.